### PR TITLE
Bugfix/coords

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Benefits of v4.0.0: each pixel is allocated the number of iterations that allow 
 
 2) <ins>changes in the allocation of water abstraction.</ins>  
 LISFLOOD v3.2.0: direct abstraction of the consumptive water use.  
-LISFLOOD v4.0.0: abstraction of the demanded water valume for each use (industrial, domestic, energy, livestock); the consumptive water use leaves the system; the unused water volume is returned to the channels.  
+LISFLOOD v4.0.0: abstraction of the demanded water volume for each use (industrial, domestic, energy, livestock); the consumptive water use leaves the system; the unused water volume is returned to the channels.  
 Minor note:  small differences in the computation of the leakages.  
 
 3) <ins>patches in the modules riceirrigation.py and frost.py to avoid non-realistic results in specific conditions.</ins>  

--- a/src/lisflood/global_modules/netcdf.py
+++ b/src/lisflood/global_modules/netcdf.py
@@ -10,23 +10,12 @@ from nine import range
 from pyproj import Proj
 
 from .settings import (calendar_inconsistency_warning, get_calendar_type, calendar, MaskAttrs, CutMap, NetCDFMetadata,
-                       LisSettings, MaskInfo)
+                       get_core_dims, LisSettings, MaskInfo)
 from .errors import LisfloodWarning, LisfloodError
 from .decorators import Cache, cached
 from .zusatz import iterOpenNetcdf
 # from .add1 import *
 from .add1 import nanCheckMap, decompress
-
-
-def get_core_dims(dims):
-    if 'x' in dims and 'y' in dims:
-        core_dims = ('y', 'x')
-    elif 'lat' in dims and 'lon' in dims:
-        core_dims = ('lat', 'lon')
-    else:
-        msg = 'Core dimension in netcdf file not recognised! Expecting (y, x) or (lat, lon), have '+str(dims)
-        LisfloodError(msg)
-    return core_dims
 
 
 def mask_array_np(data, mask, crop):
@@ -332,11 +321,9 @@ def read_lat_from_template(binding):
 
 
 def get_space_coords(template, dim_lat_y, dim_lon_x):
-
     coordinates = {}
-    coordinates[dim_lat_y] = template[dim_lat_y]
-    coordinates[dim_lon_x] = template[dim_lon_x]
-
+    coordinates[dim_lat_y] = template.coords[dim_lat_y]
+    coordinates[dim_lon_x] = template.coords[dim_lon_x]
     return coordinates
 
 

--- a/src/lisflood/global_modules/netcdf.py
+++ b/src/lisflood/global_modules/netcdf.py
@@ -331,7 +331,16 @@ def read_lat_from_template(binding):
     return lat_deg
 
 
-def get_space_coords(nrow, ncol, dim_lat_y, dim_lon_x):
+def get_space_coords(template, dim_lat_y, dim_lon_x):
+
+    coordinates = {}
+    coordinates[dim_lat_y] = template[dim_lat_y]
+    coordinates[dim_lon_x] = template[dim_lon_x]
+
+    return coordinates
+
+
+def get_space_coords_pcraster(nrow, ncol, dim_lat_y, dim_lon_x):
     cell = pcraster.clone().cellSize()
     xl = pcraster.clone().west() + cell / 2
     xr = xl + ncol * cell
@@ -386,10 +395,10 @@ def write_header(var_name, netfile, DtDay,
     ncol = np.abs(cutmap.cuts[1] - cutmap.cuts[0])
 
     dim_lat_y, dim_lon_x = get_core_dims(meta_netcdf.data)
-    latlon_coords = get_space_coords(nrow, ncol, dim_lat_y, dim_lon_x)
+    latlon_coords = get_space_coords(meta_netcdf, dim_lat_y, dim_lon_x)
 
     if dim_lon_x in meta_netcdf.data:
-        lon = nf1.createDimension(dim_lon_x, ncol)  # x 1000
+        nf1.createDimension(dim_lon_x, ncol)  # x 1000
         longitude = nf1.createVariable(dim_lon_x, 'f8', (dim_lon_x,))
         valid_attrs = [i for i in meta_netcdf.data[dim_lon_x] if i not in not_valid_attrs]
         for i in valid_attrs:
@@ -397,7 +406,7 @@ def write_header(var_name, netfile, DtDay,
     longitude[:] = latlon_coords[dim_lon_x]
 
     if dim_lat_y in meta_netcdf.data:
-        lat = nf1.createDimension(dim_lat_y, nrow)  # x 950
+        nf1.createDimension(dim_lat_y, nrow)  # x 950
         latitude = nf1.createVariable(dim_lat_y, 'f8', (dim_lat_y,))
         valid_attrs = [i for i in meta_netcdf.data[dim_lat_y] if i not in not_valid_attrs]
         for i in valid_attrs:


### PR DESCRIPTION
This is a small fix to use the netcdf template to set the coordinates in the netcdf outputs rather than using a pcraster clone. This avoids inconsistencies between the netcdf inputs and outputs.