### PR TITLE
Fix out directory not found error in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Then in the settings file the option "numberParallelThreadsKinematicWave" may ta
 Now your environment should be set up to run lisflood. Try with a prepared settings file for one of the two test catchments:
 
 ```bash
+mkdir tests/data/LF_ETRS89_UseCase/out
 python src/lisf1.py tests/data/LF_ETRS89_UseCase/settings/cold.xml
 ```
 


### PR DESCRIPTION
I tried following the example in the README (using WSL on a Windows machine) but observed the following error when running 

```bash
python src/lisf1.py tests/data/LF_ETRS89_UseCase/settings/cold.xml
```

```
Path defined in PathOut is not writable: /home/lane15/lisflood-code/tests/data/LF_ETRS89_UseCase/settings/../out
  warnings.warn(LisfloodWarning(msg))
```

This PR suggests a fix. 