### PR TITLE
Update lisflood conda environment file 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: lisflood
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu


### PR DESCRIPTION
This change removes the defaults channel from `environment.yml` so that it is compatible with ECMWF systems (see issue #184).

Merge request for development branch.

Ran the lisflood tests for development branch, which failed (same error as current development branch in repository).
Repeated the tests with the new environment file used for master branch and for the 4.3.1 tagged version of lisflood-code and all tests completed successfully. 